### PR TITLE
Fix SQL Syntax Errors in Inactive Accounts Report

### DIFF
--- a/navari_hotel_addon/navari_hotel_addon/report/inactive_accounts/inactive_accounts.js
+++ b/navari_hotel_addon/navari_hotel_addon/report/inactive_accounts/inactive_accounts.js
@@ -5,7 +5,7 @@ frappe.query_reports["Inactive Accounts"] = {
   filters: [
     {
       fieldname: "customer",
-      label: __("Customer"),
+      label: __("Search Customer"),
       fieldtype: "Link",
       options: "Customer",
     },

--- a/navari_hotel_addon/navari_hotel_addon/report/inactive_accounts/inactive_accounts.js
+++ b/navari_hotel_addon/navari_hotel_addon/report/inactive_accounts/inactive_accounts.js
@@ -4,6 +4,12 @@
 frappe.query_reports["Inactive Accounts"] = {
   filters: [
     {
+      fieldname: "customer",
+      label: __("Customer"),
+      fieldtype: "Link",
+      options: "Customer",
+    },
+    {
       fieldname: "doctype",
       label: __("Doctype"),
       fieldtype: "Select",

--- a/navari_hotel_addon/navari_hotel_addon/report/inactive_accounts/inactive_accounts.js
+++ b/navari_hotel_addon/navari_hotel_addon/report/inactive_accounts/inactive_accounts.js
@@ -2,30 +2,33 @@
 // For license information, please see license.txt
 
 frappe.query_reports["Inactive Accounts"] = {
-	"filters": [
-		{
-			"fieldname": "doctype",
-			"label": __("Doctype"),
-			"fieldtype": "Select",
-			"default": "Quotation",
-			"options": "Quotation\nSales Order\nSales Invoice",
-		},
-		{
-			"fieldname": "last_order_period",
-			"label": "Last Order Period",
-			"fieldtype": "Select",
-			"options": "\nAll\nLast Week\nLast Month\nLast Year",
-			"default": "All"
-		},
-		{
-			"fieldname": "last_order_from",
-			"label": "From Date",
-			"fieldtype": "Date"
-		},
-		{
-			"fieldname": "last_order_to",
-			"label": "To Date",
-			"fieldtype": "Date"
-		}
-	]
+  filters: [
+    {
+      fieldname: "doctype",
+      label: __("Doctype"),
+      fieldtype: "Select",
+      default: "Last Activity (All)",
+      options: "Last Activity (All)\nQuotation\nSales Order\nSales Invoice",
+      description: __(
+        "Select a single doctype or choose 'Last Activity (All)' to check across all"
+      ),
+    },
+    {
+      fieldname: "last_order_period",
+      label: "Last Order Period",
+      fieldtype: "Select",
+      options: "\nAll\nLast Week\nLast Month\nLast Year",
+      default: "All",
+    },
+    {
+      fieldname: "last_order_from",
+      label: "From Date",
+      fieldtype: "Date",
+    },
+    {
+      fieldname: "last_order_to",
+      label: "To Date",
+      fieldtype: "Date",
+    },
+  ],
 };

--- a/navari_hotel_addon/navari_hotel_addon/report/inactive_accounts/inactive_accounts.py
+++ b/navari_hotel_addon/navari_hotel_addon/report/inactive_accounts/inactive_accounts.py
@@ -235,9 +235,7 @@ def build_period_filters(filters):
             "to": filters["last_order_to"],
         })
 
-    where_sql = ""
-    if clauses:
-        where_sql = "WHERE " + " AND ".join(clauses)
+    where_sql = f"AND {' AND '.join(clauses)}" if clauses else ""
 
     return where_sql, args
 
@@ -254,5 +252,5 @@ def get_columns():
         _("Last Order Amount") + ":Currency:160",
         _("Last Order Date") + ":Date:160",
         _("Days Since Last Order") + "::160",
-        _("Source Doctype") + "::140",
+        _("Type") + "::140",
     ]

--- a/navari_hotel_addon/navari_hotel_addon/report/inactive_accounts/inactive_accounts.py
+++ b/navari_hotel_addon/navari_hotel_addon/report/inactive_accounts/inactive_accounts.py
@@ -14,21 +14,22 @@ def execute(filters=None):
         frappe.throw(_("Please select a Doctype"))
 
     columns = get_columns()
-
+    # Default behavior: run union query if "Last Activity (All)" is selected
+    if doctype == "Last Activity (All)":
+        rows = get_last_activity_all(filters)
+    else:
     # 1. Fetch data (SQL includes HAVING based on period or custom dates)
-    rows = get_sales_details(doctype, filters)
+        rows = get_sales_details(doctype, filters)
+        # insert last order amount for each row
+        data = []
+        for r in rows:
+            last_amt = get_last_sales_amt(r[0], doctype)
+            r.insert(7, last_amt)  # shifts later columns forward
+            r.append(doctype)      # Add source doctype column
+            data.append(r)
+        rows = data
 
-    # 2. For each row, insert the value of the very last order before returning
-    data = []
-    for r in rows:
-        # r indices: 0=name,1=customer_name,2=territory,3=group,
-        #            4=num_orders,5=total_value,6=considered,
-        #            7=last_order_date,8=days_since_last_order
-        last_amt = get_last_sales_amt(r[0], doctype)
-        r.insert(7, last_amt)
-        data.append(r)
-
-    return columns, data
+    return columns, rows
 
 
 def get_sales_details(doctype, filters):
@@ -131,16 +132,106 @@ def get_last_sales_amt(customer, doctype):
     return (res and res[0][0]) or 0
 
 
+
 def get_columns():
-	return [
-		_("Customer") + ":Link/Customer:120",
-		_("Customer Name") + ":Data:120",
-		_("Territory") + "::120",
-		_("Customer Group") + "::120",
-		_("Number of Order") + "::120",
-		_("Total Order Value") + ":Currency:120",
-		_("Total Order Considered") + ":Currency:160",
-		_("Last Order Amount") + ":Currency:160",
-		_("Last Order Date") + ":Date:160",
-		_("Days Since Last Order") + "::160",
-	]
+    return [
+        _("Customer") + ":Link/Customer:120",
+        _("Customer Name") + ":Data:120",
+        _("Territory") + "::120",
+        _("Customer Group") + "::120",
+        _("Number of Order") + "::120",
+        _("Total Order Value") + ":Currency:120",
+        _("Total Order Considered") + ":Currency:160",
+        _("Last Order Amount") + ":Currency:160",
+        _("Last Order Date") + ":Date:160",
+        _("Days Since Last Order") + "::160",
+        _("Source Doctype") + "::140",
+    ]
+def get_last_activity_all(filters):
+    """Get most recent activity across Quotation, Sales Order, and Sales Invoice for each customer,
+    applying period/date range filters."""
+    
+    mapping = [
+        ("Quotation", "party_name", "transaction_date"),
+        ("Sales Order", "customer", "transaction_date"),
+        ("Sales Invoice", "customer", "posting_date"),
+    ]
+
+    period_filter_sql, date_args = build_period_filters(filters)
+
+    queries = []
+    for doctype, customer_field, date_field in mapping:
+        queries.append(f"""
+            SELECT
+                cust.name AS customer,
+                cust.customer_name,
+                cust.territory,
+                cust.customer_group,
+                1 AS num_of_order,
+                so.base_net_total AS total_order_value,
+                so.base_net_total AS total_order_considered,
+                so.base_net_total AS last_order_amount,
+                so.`{date_field}` AS last_order_date,
+                DATEDIFF(CURDATE(), so.`{date_field}`) AS days_since_last_order,
+                '{doctype}' AS source_doctype
+            FROM `tabCustomer` cust
+            JOIN `tab{doctype}` so
+              ON cust.name = so.`{customer_field}`
+             AND so.docstatus = 1
+            {period_filter_sql.replace('last_order_date', f"so.`{date_field}`")}
+        """)
+
+    union_query = " UNION ALL ".join(queries)
+
+    # Wrap to get only the latest per customer
+    final_query = f"""
+        SELECT t.* 
+        FROM (
+            {union_query}
+        ) AS t
+        INNER JOIN (
+            SELECT customer, MAX(last_order_date) AS max_date
+            FROM ({union_query}) AS sub
+            GROUP BY customer
+        ) AS latest
+        ON t.customer = latest.customer
+        AND t.last_order_date = latest.max_date
+        ORDER BY t.last_order_date DESC
+    """
+
+    return frappe.db.sql(final_query, date_args, as_list=1)
+def build_period_filters(filters):
+    """Return SQL WHERE clause and args for period or custom date range."""
+    clauses = []
+    args = {}
+
+    period = filters.get("last_order_period")
+    if period == "Last Week":
+        clauses.append("""
+            last_order_date BETWEEN
+              DATE_SUB(CURDATE(), INTERVAL (WEEKDAY(CURDATE())+7) DAY)
+            AND
+              DATE_SUB(CURDATE(), INTERVAL (WEEKDAY(CURDATE())+1) DAY)
+        """)
+    elif period == "Last Month":
+        clauses.append("""
+            last_order_date BETWEEN
+              DATE_SUB(DATE_SUB(CURDATE(), INTERVAL DAY(CURDATE())-1 DAY), INTERVAL 1 MONTH)
+            AND
+              LAST_DAY(DATE_SUB(CURDATE(), INTERVAL 1 MONTH))
+        """)
+    elif period == "Last Year":
+        clauses.append("YEAR(last_order_date) = YEAR(CURDATE()) - 1")
+
+    if filters.get("last_order_from") and filters.get("last_order_to"):
+        clauses.append("last_order_date BETWEEN %(from)s AND %(to)s")
+        args.update({
+            "from": filters["last_order_from"],
+            "to": filters["last_order_to"],
+        })
+
+    where_sql = ""
+    if clauses:
+        where_sql = "WHERE " + " AND ".join(clauses)
+
+    return where_sql, args

--- a/navari_hotel_addon/navari_hotel_addon/report/inactive_accounts/inactive_accounts.py
+++ b/navari_hotel_addon/navari_hotel_addon/report/inactive_accounts/inactive_accounts.py
@@ -20,15 +20,17 @@ def execute(filters=None):
     else:
     # 1. Fetch data (SQL includes HAVING based on period or custom dates)
         rows = get_sales_details(doctype, filters)
-        # insert last order amount for each row
+     # 2. insert last order amount for each row
         data = []
         for r in rows:
             last_amt = get_last_sales_amt(r[0], doctype)
+        # r indices: 0=name,1=customer_name,2=territory,3=group,
+        #            4=num_orders,5=total_value,6=considered,
+        #            7=last_order_date,8=days_since_last_order
             r.insert(7, last_amt)  # shifts later columns forward
             r.append(doctype)      # Add source doctype column
             data.append(r)
         rows = data
-
     return columns, rows
 
 
@@ -52,6 +54,15 @@ def get_sales_details(doctype, filters):
         """
     else:
         total_considered = "SUM(so.base_net_total) AS total_order_considered"
+        
+     # WHERE conditions (customer and docstatus)
+    where_clauses = ["so.docstatus = 1"]
+    args = {}
+    if filters.get("customer"):
+        where_clauses.append("cust.name = %(customer)s")
+        args["customer"] = filters["customer"]
+
+    where_sql = " AND ".join(where_clauses)
 
     # Base aggregation
     base = f"""
@@ -68,13 +79,12 @@ def get_sales_details(doctype, filters):
         FROM `tabCustomer` cust
         JOIN `tab{doctype}` so
           ON cust.name = so.`{customer_field}`
-         AND so.docstatus = 1
+        WHERE {where_sql}
         GROUP BY cust.name
     """
 
     clauses = []
-    args    = {}
-
+    
     period = filters.get("last_order_period")
     if period == "Last Week":
         # previous Mon–Sun
@@ -132,21 +142,6 @@ def get_last_sales_amt(customer, doctype):
     return (res and res[0][0]) or 0
 
 
-
-def get_columns():
-    return [
-        _("Customer") + ":Link/Customer:120",
-        _("Customer Name") + ":Data:120",
-        _("Territory") + "::120",
-        _("Customer Group") + "::120",
-        _("Number of Order") + "::120",
-        _("Total Order Value") + ":Currency:120",
-        _("Total Order Considered") + ":Currency:160",
-        _("Last Order Amount") + ":Currency:160",
-        _("Last Order Date") + ":Date:160",
-        _("Days Since Last Order") + "::160",
-        _("Source Doctype") + "::140",
-    ]
 def get_last_activity_all(filters):
     """Get most recent activity across Quotation, Sales Order, and Sales Invoice for each customer,
     applying period/date range filters."""
@@ -158,6 +153,12 @@ def get_last_activity_all(filters):
     ]
 
     period_filter_sql, date_args = build_period_filters(filters)
+    
+       # Customer filter
+    customer_condition = ""
+    if filters.get("customer"):
+        customer_condition = "AND cust.name = %(customer)s"
+        date_args["customer"] = filters["customer"]
 
     queries = []
     for doctype, customer_field, date_field in mapping:
@@ -177,7 +178,9 @@ def get_last_activity_all(filters):
             FROM `tabCustomer` cust
             JOIN `tab{doctype}` so
               ON cust.name = so.`{customer_field}`
-             AND so.docstatus = 1
+              AND so.docstatus = 1
+            WHERE 1=1
+              {customer_condition}
             {period_filter_sql.replace('last_order_date', f"so.`{date_field}`")}
         """)
 
@@ -200,6 +203,8 @@ def get_last_activity_all(filters):
     """
 
     return frappe.db.sql(final_query, date_args, as_list=1)
+
+
 def build_period_filters(filters):
     """Return SQL WHERE clause and args for period or custom date range."""
     clauses = []
@@ -235,3 +240,19 @@ def build_period_filters(filters):
         where_sql = "WHERE " + " AND ".join(clauses)
 
     return where_sql, args
+
+
+def get_columns():
+    return [
+        _("Customer") + ":Link/Customer:120",
+        _("Customer Name") + ":Data:120",
+        _("Territory") + "::120",
+        _("Customer Group") + "::120",
+        _("Number of Order") + "::120",
+        _("Total Order Value") + ":Currency:120",
+        _("Total Order Considered") + ":Currency:160",
+        _("Last Order Amount") + ":Currency:160",
+        _("Last Order Date") + ":Date:160",
+        _("Days Since Last Order") + "::160",
+        _("Source Doctype") + "::140",
+    ]


### PR DESCRIPTION
This PR fixes a syntax issue in the Inactive Accounts report, specifically in the union queries used for the "Last Activity (All)" option. Previously, multiple WHERE clauses were present in the same query, causing SQL syntax errors.

**Changes include:**

Consolidated multiple WHERE clauses into a single clause with proper AND conditions.

Correctly applied period filters (Last Week, Last Month, Last Year) and custom date ranges.

Improved query reliability and maintainability.

**Impact:**

Users can now generate the Inactive Accounts report without encountering SQL errors.

Query results remain accurate and consistent with selected filters.